### PR TITLE
Update eportal-installer_v1.4.sh - patch for predictable (interface) names

### DIFF
--- a/eportal-installer_v1.4.sh
+++ b/eportal-installer_v1.4.sh
@@ -190,8 +190,13 @@ X19fXy8KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
 ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAg
 ICAgICAgICAgICAgICAgICAgICAK"
 
-# grab your IP address
-ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+
+# get interface for the default route,
+# usually the same way the system is accessed from outside
+DEFAULT_INTERFACE=$(/sbin/ip route list default|awk '{print $5}')
+
+# grab your IP address from default interface
+ip4=$(/sbin/ip -o -4 addr list ${DEFAULT_INTERFACE} | awk '{print $4}' | cut -d/ -f1)
 
 echo
 echo


### PR DESCRIPTION
With predictable names the default interface isn't eth0 anymore. As the system usually is connected via the same interface as the default route is using, get the interface used for the default route and then gram the ip address of this interface.